### PR TITLE
прижимаем footer IE 10-11

### DIFF
--- a/src/blocks/page/page.scss
+++ b/src/blocks/page/page.scss
@@ -46,6 +46,8 @@ body {
   background-color: #fff;
   margin: 0;
   min-height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 [tabindex='-1']:focus {

--- a/src/blocks/page/page.scss
+++ b/src/blocks/page/page.scss
@@ -43,11 +43,11 @@
 
 body {
   // Типографика проекта — в блоке typo
+  display: flex;           // Исправляем баг в IE для min-height and flexbox (flex-direction:column)
+  flex-direction: column;  // и прижимаем footer в IE 10-11
   background-color: #fff;
   margin: 0;
   min-height: 100%;
-  display: flex;
-  flex-direction: column;
 }
 
 [tabindex='-1']:focus {


### PR DESCRIPTION
Приветствую!
Эти две строчки помогут прижать footer в IE10-11
решение позаимствовано [отсюда](https://github.com/philipwalton/flexbugs#3-min-height-on-a-flex-container-wont-apply-to-its-flex-items)

до:
![before](https://user-images.githubusercontent.com/22531735/32863936-89583dac-ca5d-11e7-9848-1bebcdb40c21.png)
после:
![after](https://user-images.githubusercontent.com/22531735/32863949-9ee14b32-ca5d-11e7-8cc3-f476b75aa615.png)
