### PR TITLE
fixed write to entry.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -283,9 +283,8 @@ function writeJsRequiresFile(cb) {
     jsRequires += `require('${src}');\n`;
   });
   const allBlocksWithJsFiles = getDirectories('js');
-  const allUsedBlocks = nth.blocksFromHtml.concat(nth.config.alwaysAddBlocks);
   allBlocksWithJsFiles.forEach(function(blockWithJsFile){
-    if (allUsedBlocks.indexOf(blockWithJsFile) == -1) return;
+    if (nth.blocksFromHtml.indexOf(blockWithJsFile) == -1) return;
     jsRequires += `require('../blocks/${blockWithJsFile}/${blockWithJsFile}.js');\n`;
   });
   nth.config.addJsAfter.forEach(function(src) {


### PR DESCRIPTION
Исправлен баг с записью элементов в `entry.js`. В текущем виде у меня добавлялись только элементы из обязательного блока `alwaysAddBlocks`.